### PR TITLE
chore: add Vue bundler feature flags

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const { StylableWebpackPlugin } = require("@stylable/webpack-plugin");
 const { VueLoaderPlugin } = require("vue-loader");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const webpack = require("webpack");
 
 /** @type {import('webpack').Configuration} */
 module.exports = {
@@ -20,5 +21,9 @@ module.exports = {
     new StylableWebpackPlugin(),
     new VueLoaderPlugin(),
     new HtmlWebpackPlugin(),
+    new webpack.DefinePlugin({
+      __VUE_OPTIONS_API__: "true",
+      __VUE_PROD_DEVTOOLS__: "false",
+    }),
   ],
 };


### PR DESCRIPTION
From Vue 3 there is a need to provide some flags through the bundler: https://github.com/vuejs/core/tree/main/packages/vue#bundler-build-feature-flags

Not provided, they have defaults, but also adds warning in the console.